### PR TITLE
fix: check bash path before invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 os:
   - linux
   - windows
@@ -6,7 +5,7 @@ language: node_js
 
 # https://github.com/nodejs/Release#end-of-life-releases
 node_js:
-  - '15'
+  - '16'
   - '14'
   - '12'
   - '10'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: node_js
 
 # https://github.com/nodejs/Release#end-of-life-releases
 node_js:
+  - '15'
   - '14'
   - '12'
   - '10'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: false
 os:
   - linux
-  - osx
+  - windows
 language: node_js
+
+# https://github.com/nodejs/Release#end-of-life-releases
 node_js:
-  - node
+  - '14'
+  - '12'
+  - '10'
   - '8'
-  - '7'
-  - '6'
-  - '5'
-  - '4'

--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ glob.sync = function(pattern, options) {
     return (opts.nullglob || fs.existsSync(fp)) ? [pattern] : [];
   }
 
-  var cp = spawn.sync(bashPath, cmd(pattern, opts), opts);
+  var cp = spawn.sync(getBash(), cmd(pattern, opts), opts);
   var error = cp.stderr ? String(cp.stderr).trim() : null;
   if (error) {
     err = handleError(error, pattern, opts);
@@ -264,7 +264,7 @@ function bash(pattern, options, cb) {
       return;
     }
 
-    var cp = spawn(bashPath, cmd(pattern, options), options);
+    var cp = spawn(getBash(), cmd(pattern, options), options);
     var buf = new Buffer(0);
 
     cp.stdout.on('data', function(data) {
@@ -473,6 +473,22 @@ function nonGlob(pattern, options, cb) {
 
 function emitMatches(str, pattern, options) {
   glob.emit('match', getFiles(str, pattern, options), options.cwd);
+}
+
+/**
+ * Returns bash path if exists.
+ * @ignore
+ * @return {String} Bash bin path.
+ *
+ */
+function getBash() {
+  const bashBinPath = bashPath()
+
+  if (!bashBinPath) {
+    throw new TypeError('`bash` not found')
+  }
+
+  return bashBinPath
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=4.0"
+    "node": ">=8.0"
   },
   "scripts": {
     "test": "mocha"
@@ -22,9 +22,9 @@
   "dependencies": {
     "bash-path": "^2.0.1",
     "component-emitter": "^1.3.0",
-    "cross-spawn": "^5.1.0",
+    "cross-spawn": "^7.0.3",
     "each-parallel-async": "^1.0.0",
-    "extend-shallow": "^2.0.1",
+    "extend-shallow": "^3.0.2",
     "is-extglob": "^2.1.1",
     "is-glob": "^4.0.1"
   },
@@ -34,12 +34,12 @@
     "async-array-reduce": "^1.0.0",
     "delete": "^1.1.0",
     "glob": "^7.1.6",
-    "gulp-format-md": "^1.0.0",
+    "gulp-format-md": "^2.0.0",
     "minimist": "^1.2.5",
     "mkdirp": "^0.5.5",
-    "mocha": "^6.2.3",
+    "mocha": "^7.2.0",
     "mock-require": "^3.0.3",
-    "sinon": "^9.1.0"
+    "sinon": "^9.2.1"
   },
   "keywords": [
     "bash",

--- a/package.json
+++ b/package.json
@@ -20,24 +20,26 @@
     "test": "mocha"
   },
   "dependencies": {
-    "bash-path": "^1.0.1",
-    "component-emitter": "^1.2.1",
+    "bash-path": "^2.0.1",
+    "component-emitter": "^1.3.0",
     "cross-spawn": "^5.1.0",
     "each-parallel-async": "^1.0.0",
     "extend-shallow": "^2.0.1",
     "is-extglob": "^2.1.1",
-    "is-glob": "^4.0.0"
+    "is-glob": "^4.0.1"
   },
   "devDependencies": {
     "arr-union": "^3.1.0",
     "array-unique": "^0.3.2",
     "async-array-reduce": "^1.0.0",
     "delete": "^1.1.0",
-    "glob": "^7.1.2",
+    "glob": "^7.1.6",
     "gulp-format-md": "^1.0.0",
-    "minimist": "^1.2.0",
-    "mkdirp": "^0.5.1",
-    "mocha": "^3.2.0"
+    "minimist": "^1.2.5",
+    "mkdirp": "^0.5.5",
+    "mocha": "^6.2.3",
+    "mock-require": "^3.0.3",
+    "sinon": "^9.1.0"
   },
   "keywords": [
     "bash",

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "array-unique": "^0.3.2",
     "async-array-reduce": "^1.0.0",
     "delete": "^1.1.0",
-    "glob": "^7.1.6",
+    "glob": "^7.1.7",
     "gulp-format-md": "^2.0.0",
     "minimist": "^1.2.5",
     "mkdirp": "^0.5.5",
     "mocha": "^7.2.0",
     "mock-require": "^3.0.3",
-    "sinon": "^9.2.1"
+    "sinon": "^9.2.4"
   },
   "keywords": [
     "bash",

--- a/test/api.js
+++ b/test/api.js
@@ -2,6 +2,8 @@
 
 require('mocha');
 var assert = require('assert');
+var sinon = require('sinon');
+var mock = require('mock-require');
 var glob = require('..');
 
 describe('bash-glob', function() {
@@ -47,5 +49,22 @@ describe('bash-glob', function() {
         cb();
       }
     });
+  });
+
+  it('throws exception if `bash` not found', function() {
+    var bashPathSpy = sinon.spy(function () { return null; });
+    mock('bash-path', bashPathSpy);
+
+    var glob = mock.reRequire('..')
+
+    try {
+      glob.sync(['*']);
+
+    } catch (err) {
+      assert(err);
+      assert.equal(err.message, '`bash` not found');
+    }
+
+    mock.stop('bash-path');
   });
 });


### PR DESCRIPTION
Hi there.

Current **bash-glob** impl does not verify that `bash` bin exists and sometimes an unhandled exception is thrown. This PR brings the missed check.
```bash
$ npx handpick --target=releaseDependencies && npx multi-semantic-release -d
npx: installed 26 in 3.643s
- Hand picking DIRTY releaseDependencies via NPM
✔ Hand picking DIRTY releaseDependencies via NPM
multi-semantic-release version: 2.4.5
semantic-release version: 17.1.1
flags: {
  "d": true,
  "sequentialInit": false,
  "firstParent": false,
  "debug": false
}
[multi-semantic-release]: TypeError [ERR_INVALID_ARG_TYPE]: The "file" argument must be of type string. Received type undefined
    at validateString (internal/validators.js:112:11)
    at normalizeSpawnArguments (child_process.js:398:3)
    at spawnSync (child_process.js:557:16)
    at Function.spawnSync [as sync] (/builds/project/node_modules/bash-glob/node_modules/cross-spawn/index.js:46:14)
    at Function.glob.sync (/builds/project/node_modules/bash-glob/index.js:189:18)
    at /builds/project/node_modules/bash-glob/index.js:160:29
    at Array.reduce (<anonymous>)
    at Function.glob.sync (/builds/project/node_modules/bash-glob/index.js:159:20)
    at getWorkspacesYarn (/builds/project/node_modules/multi-semantic-release/lib/getWorkspacesYarn.js:26:26)
    at module.exports (/builds/project/node_modules/multi-semantic-release/bin/runner.js:22:17) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```
_Originally posted by @younes200 in https://github.com/dhoulb/multi-semantic-release/issues/35#issue-684080038_ 

bash-glob/index.js
```js
var bashPath = require('bash-path');
//...
var cp = spawn(bashPath, cmd(pattern, options), options);

```
cross-spawn.index.js
```js
var cp = require('child_process');
var parse = require('./lib/parse');
var cpSpawnSync = cp.spawnSync;
//...

// Parse the arguments
parsed = parse(command, args, options);

// Spawn the child process
result = cpSpawnSync(parsed.command, parsed.args, parsed.options);
```